### PR TITLE
Feature: optimized pods

### DIFF
--- a/babel.config.json
+++ b/babel.config.json
@@ -4,7 +4,8 @@
   ],
   "env": {
     "test": {
-      "presets": [["@babel/preset-env"]]
+      "presets": [["@babel/preset-env"]],
+      "plugins": [["@babel/transform-runtime"]]
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
   "scripts": {
     "bundle-check": "ANALYZE_BUNDLE=true rollup --config",
     "build": "rollup --config",
+    "watch": "rollup --config --watch",
     "release": "MINIMIZE=true rollup --config",
     "prepublishOnly": "npm run release",
     "start": "DEV=true rollup --config --watch",

--- a/src/parsers/vast/vast.js
+++ b/src/parsers/vast/vast.js
@@ -34,17 +34,20 @@ export default class VASTManager {
       .then(response => this._filterOrGetNextAds(response))
   }
 
-  _filterOrGetNextAds(response) {
+  _filterOrGetNextAds(response, adsToReturn = []) {
     const { ads } = response
 
     if (!ads || ads.length === 0) throw new Error('Empty ads')
 
-    // TODO: support for ad pods (n ads)
-    const hasMediaFiles = ads[0].creatives.some(creative => creative.mediaFiles)
-    if ((!ads[0].creatives || !hasMediaFiles) && this.client.hasRemainingAds())
-      return this.client.getNextAds().then(response => this._filterOrGetNextAds(response))
+    ads.forEach(ad => {
+      const hasMediaFiles = ad.creatives && ad.creatives.some(creative => creative.mediaFiles)
+      if (!hasMediaFiles && this.client.hasRemainingAds()) {
+        this.client.getNextAds().then(response => this._filterOrGetNextAds(response, adsToReturn))
+      } else {
+        adsToReturn.push(ad)
+      }
+    })
 
-    return ads[0]
-    // TODO: support for ad pods (n ads)
+    return adsToReturn
   }
 }

--- a/src/parsers/vast/vast.test.js
+++ b/src/parsers/vast/vast.test.js
@@ -2,14 +2,14 @@ import VASTManager from './vast'
 import { VASTClient } from 'vast-client'
 
 describe('VASTManager', () => {
-  test('creates one VASTClient instance when is built', () => {
+  it('creates one VASTClient instance when is built', () => {
     const VASTHandler = new VASTManager()
 
     expect(VASTHandler.client instanceof VASTClient).toBeTruthy()
   })
 
   describe('request method', () => {
-    test('returns one error for no adData received', done => {
+    it('returns one error for no adData received', done => {
       const VASTHandler = new VASTManager()
 
       VASTHandler.request()
@@ -19,7 +19,7 @@ describe('VASTManager', () => {
         })
     })
 
-    test('returns one error for invalid adData received', done => {
+    it('returns one error for invalid adData received', done => {
       const VASTHandler = new VASTManager()
 
       VASTHandler.request({})
@@ -29,35 +29,35 @@ describe('VASTManager', () => {
         })
     })
 
-    test('returns a promise for a valid received adData', () => {
+    it('returns a promise for a valid received adData', async () => {
       const VASTHandler = new VASTManager()
 
       jest.spyOn(VASTHandler, '_requestVASTAdInformation').mockImplementation(() => new Promise(resolve => resolve()))
 
       let response = VASTHandler.request({ '#cdata': 'https://ad-server.com/test?vad_type=linear' })
 
-      expect(response instanceof Promise).toBeTruthy()
+      await expect(response instanceof Promise).toBeTruthy()
 
       response = VASTHandler.request([{ '#cdata': 'https://ad-server.com/test?vad_type=linear' }])
 
-      expect(response instanceof Promise).toBeTruthy()
+      await expect(response instanceof Promise).toBeTruthy()
     })
 
-    test('returns one error for invalid ads response', () => {
+    it('returns one error for invalid ads response', async () => {
       const VASTHandler = new VASTManager()
 
       jest.spyOn(VASTHandler.client, 'get').mockImplementationOnce(() => new Promise(resolve => resolve({})))
 
-      expect(VASTHandler.request({ '#cdata': 'https://ad-server.com/test?vad_type=linear' })).rejects.toThrow('Empty ads')
+      await expect(VASTHandler.request({ '#cdata': 'https://ad-server.com/test?vad_type=linear' })).rejects.toThrow('Empty ads')
     })
 
-    test('returns the ad content after the promise is resolved', () => {
+    test('returns the ad content after the promise is resolved', async () => {
       const VASTHandler = new VASTManager()
-      const responseMock = { ads: [{ creatives: [{ mediaFiles: {} }] }] }
+      const responseMock = { ads: [{ creatives: [{ mediaFiles: {} }] }, { creatives: [{ mediaFiles: {} }] }] }
 
       jest.spyOn(VASTHandler.client, 'get').mockImplementationOnce(() => new Promise(resolve => resolve(responseMock)))
 
-      expect(VASTHandler.request({ '#cdata': 'https://ad-server.com/test?vad_type=linear' })).resolves.toEqual(responseMock.ads[0])
+      await expect(VASTHandler.request({ '#cdata': 'https://ad-server.com/test?vad_type=linear' })).resolves.toEqual(responseMock.ads)
     })
   })
 })


### PR DESCRIPTION
## Summary

This PR aims to add support to Optimized Ad Pods

## Changes

`src/parsers/vast/vast.js`: adds support to optimized ad pods

## How to test

Make a request to [this URL](http://pubads.g.doubleclick.net/gampad/ads?sz=1280x720&iu=/95377733/globocom.teste&cmsid=11413&vid=7076253&cust_params=gcom.teste%3Dprecomskip%2Cmidcomskip%2Cpossemskip%26video_subscription%3Dtrue&ciu_szs=940x360&impl=s&gdfp_req=1&env=vp&output=xml_vast3&unviewed_position_start=1&url=%5Breferrer_url%5D&ad_rule=03&video_url_to_fetch=%5Bdescription_url%5D&vad_type=linear&vpos=preroll&pod=1&vrid=11413&min_ad_duration=0&max_ad_duration=182000&ppos=1&lip=true&video_doc_id=8238028&kfa=0&tfcd=0) and check if the response contains all the ads present in the VAST file (the first Midroll ad break contains a VAST with 4 ads in the same pod).