### PR TITLE
Updating lib clappr-ima-parser to request all Ads from the same segment

### DIFF
--- a/src/ima-parser.js
+++ b/src/ima-parser.js
@@ -5,7 +5,7 @@ import VASTManager from './parsers/vast'
 export default class IMAParser {
   constructor() {
     this._VMAPHandler = new VMAPManager()
-    this._VASTHandler = new VASTManager()
+    this.VASTHandler = new VASTManager()
   }
 
   /**
@@ -32,7 +32,7 @@ export default class IMAParser {
    * @returns {Promise} Promise resolved with current available ads of the respected Ad tag.
    */
   requestAds(adTag) {
-    return this._VASTHandler.request(adTag)
+    return this.VASTHandler.request(adTag)
       .then(ad => {
         return ad
       })

--- a/src/ima-parser.test.js
+++ b/src/ima-parser.test.js
@@ -12,7 +12,7 @@ describe('IMAParser', () => {
     const imaParser = new IMAParser()
 
     expect(imaParser._VMAPHandler instanceof VMAPManager).toBeTruthy()
-    expect(imaParser._VASTHandler instanceof VASTManager).toBeTruthy()
+    expect(imaParser.VASTHandler instanceof VASTManager).toBeTruthy()
   })
 
   describe('requestAdBreaks method', () => {
@@ -50,7 +50,7 @@ describe('IMAParser', () => {
     it('returns a promise', () => {
       const imaParser = new IMAParser()
       const adBreakMock = { category: 'preroll', timeOffset: 1000, adTag: {} }
-      jest.spyOn(imaParser._VASTHandler, 'request').mockImplementationOnce(() => new Promise(resolve => resolve()))
+      jest.spyOn(imaParser.VASTHandler, 'request').mockImplementationOnce(() => new Promise(resolve => resolve()))
       const result = imaParser.requestAds(adBreakMock.adTag)
 
       expect(result instanceof Promise).toBeTruthy()

--- a/src/parsers/vast/adbreak.js
+++ b/src/parsers/vast/adbreak.js
@@ -1,0 +1,15 @@
+class AdBreak {
+    constructor(adData) {
+      this.content = Array.isArray(adData) ? adData : [adData]
+    }
+
+    get adDataUrls() {
+      return this.content.map(this.formatUrlString)
+    }
+
+    formatUrlString(adUrl) {
+      return adUrl['#cdata'].replace(/[\s\n]+/, '')
+    }
+}
+
+export default AdBreak


### PR DESCRIPTION
## Summary

Depends on the inclusion of the [Feature: optimized pods](https://github.com/clappr/clappr-ima-parser/pull/3)

This PR is responsible for allowing the reading of a playlist with several advertisements coming from the same segment

## Changes

`src/parsers/vast/vast.js`: adds support to get multiple ads from the same segment

## How to test
1. Access `clappr-ima-parser` on branch(`feature/multiple-ads-ima-parser-lib`) and then run the following commands: `yarn link` and `yarn run watch`.
2. In a new terminal, you must access the `player-plugins` folder in the branch(`feature/multiple-ads-ima-parser-lib`) and then run the following commands: ﻿
  a. `yarn link "@clappr/ima-parser"`
  b. `yarn link`
  c. `yarn run watch`
3. For show `ads` you need to execute thoses especific steps first: [Show pubads during the video](https://gitlab.globoi.com/videos-5/player-plugins/-/merge_requests/167#how-to-test)
4. Open a new terminal, access `player-tvs-lite` and run: 
  a. `yarn link "@player/plugins"` ﻿
  b. `yarn start`
﻿5. On the console, trigger the event `this.player.container.trigger('ads:request:ready’)`
6. Add a debugger in the `ads_manager.js` file below line 110
7. Using a debugging proxy tool such as [Proxyman](https://proxyman.io/), intercept the responses from `https://pubads.g.doubleclick.net/gampad/ads?` and change the body of the VMAP so that it only has the items from the `PreRoll`
  a. You should ignore the first intercepted item and only change the second intercepted item with this URL.
8. When running, check when the debugger fires that `adsQueue` has the same amount of items as you configured in `PreRoll`
9. To simulate an error, you can change one of the PreRoll body items by looking for `vad_type` and changing the text to `nonlinear` and verifying that only the item with no error will be displayed.


## After this PR

- Expectation:
![ads-multiple-ima-paser](https://user-images.githubusercontent.com/96535792/171276894-19040ddd-0735-420b-8ff7-63816df506f0.png)

- Error:
![ads-multiple-error-ima-paser](https://user-images.githubusercontent.com/96535792/171276946-533df14c-dbdd-4f18-96bd-6b05ead2cf2a.png)



