### PR TITLE
Updating lib clappr-ima-parser to request all Ads from the same segment #4

### DIFF
--- a/babel.config.json
+++ b/babel.config.json
@@ -4,7 +4,8 @@
   ],
   "env": {
     "test": {
-      "presets": [["@babel/preset-env"]]
+      "presets": [["@babel/preset-env"]],
+      "plugins": [["@babel/transform-runtime"]]
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
   "scripts": {
     "bundle-check": "ANALYZE_BUNDLE=true rollup --config",
     "build": "rollup --config",
+    "watch": "rollup --config --watch",
     "release": "MINIMIZE=true rollup --config",
     "prepublishOnly": "npm run release",
     "start": "DEV=true rollup --config --watch",

--- a/src/ima-parser.test.js
+++ b/src/ima-parser.test.js
@@ -8,7 +8,7 @@ import VASTManager from './parsers/vast'
 import { standardParsedVMAPMock } from './mocks/valid-vmap'
 
 describe('IMAParser', () => {
-  test('creates internal references of necessary parsers at constructor', () => {
+  it('creates internal references of necessary parsers at constructor', () => {
     const imaParser = new IMAParser()
 
     expect(imaParser._VMAPHandler instanceof VMAPManager).toBeTruthy()
@@ -16,7 +16,7 @@ describe('IMAParser', () => {
   })
 
   describe('requestAdBreaks method', () => {
-    test('returns a promise', () => {
+    it('returns a promise', () => {
       const imaParser = new IMAParser()
       jest.spyOn(imaParser._VMAPHandler, 'request').mockImplementationOnce(() => new Promise(resolve => resolve(standardParsedVMAPMock)))
       const result = imaParser.requestAdBreaks('https://server.com/vmap')
@@ -24,7 +24,7 @@ describe('IMAParser', () => {
       expect(result instanceof Promise).toBeTruthy()
     })
 
-    test('returns an AdBreaks list after the returned promise is resolved', done => {
+    it('returns an AdBreaks list after the returned promise is resolved', done => {
       const imaParser = new IMAParser()
       jest.spyOn(imaParser._VMAPHandler, 'request').mockImplementationOnce(() => new Promise(resolve => resolve(standardParsedVMAPMock)))
 
@@ -35,7 +35,7 @@ describe('IMAParser', () => {
         })
     })
 
-    test('returns one error after the returned promise is rejected', done => {
+    it('returns one error after the returned promise is rejected', done => {
       const imaParser = new IMAParser()
       jest.spyOn(imaParser._VMAPHandler, 'request').mockImplementationOnce(() => new Promise((_, reject) => reject('expected error')))
       imaParser.requestAdBreaks('https://server.com/vmap')
@@ -47,7 +47,7 @@ describe('IMAParser', () => {
   })
 
   describe('requestAds method', () => {
-    test('returns a promise', () => {
+    it('returns a promise', () => {
       const imaParser = new IMAParser()
       const adBreakMock = { category: 'preroll', timeOffset: 1000, adTag: {} }
       jest.spyOn(imaParser._VASTHandler, 'request').mockImplementationOnce(() => new Promise(resolve => resolve()))
@@ -56,7 +56,7 @@ describe('IMAParser', () => {
       expect(result instanceof Promise).toBeTruthy()
     })
 
-    test('returns one error after the returned promise is rejected', done => {
+    it('returns one error after the returned promise is rejected', done => {
       const imaParser = new IMAParser()
       imaParser.requestAds()
         .catch(error => {

--- a/src/parsers/vmap/vmap.test.js
+++ b/src/parsers/vmap/vmap.test.js
@@ -18,11 +18,11 @@ describe('VMAPManager', () => {
       expect(response instanceof Promise).toBeTruthy()
     })
 
-    test('throws one error if receives a invalid URL', () => {
+    test('throws one error if receives a invalid URL', async () => {
       global.fetch = jest.fn(() => new Promise((_, reject) => reject('Network response was not ok')))
       const VASTHandler = new VMAPManager()
 
-      expect(VASTHandler.request('https://invali-ad-server.com/test')).rejects.toMatch('Network response was not ok')
+      await expect(VASTHandler.request('https://invali-ad-server.com/test')).rejects.toMatch('Network response was not ok')
     })
   })
 
@@ -54,18 +54,18 @@ describe('VMAPManager', () => {
       expect(Array.isArray(response[0].adTag)).not.toHaveProperty('@templateType')
     })
 
-    test('returns a rejected promise for IAB VMAP format decode errors', () => {
+    test('returns a rejected promise for IAB VMAP format decode errors', async () => {
       const VASTHandler = new VMAPManager()
       const invalidStandardVMAP = standardParsedVMAPMock
       invalidStandardVMAP['vmap:AdBreak'] = 'invalid'
 
-      expect(VASTHandler.filterRawData(invalidStandardVMAP)).rejects.toThrow('Cannot read property \'vmap:AdTagURI\' of undefined')
+      await expect(VASTHandler.filterRawData(invalidStandardVMAP)).rejects.toThrow('Cannot read property \'vmap:AdTagURI\' of undefined')
     })
 
-    test('returns a rejected promise for Custom VMAP format decode errors', () => {
+    test('returns a rejected promise for Custom VMAP format decode errors', async () => {
       const VASTHandler = new VMAPManager()
 
-      expect(VASTHandler.filterRawData({ p: null, q: null })).rejects.toThrow('Cannot read property \'Ad\' of null')
+      await expect(VASTHandler.filterRawData({ p: null, q: null })).rejects.toThrow('Cannot read property \'Ad\' of null')
     })
   })
 })

--- a/src/parsers/vmap/vmap.test.js
+++ b/src/parsers/vmap/vmap.test.js
@@ -9,7 +9,7 @@ describe('VMAPManager', () => {
   afterEach(() => { fetch.mockClear() })
 
   describe('request method', () => {
-    test('returns a promise', () => {
+    it('returns a promise', () => {
       global.fetch = jest.fn(() => new Promise(resolve => resolve({ ok: 200, text: () => {} })))
 
       const VASTHandler = new VMAPManager()
@@ -18,7 +18,7 @@ describe('VMAPManager', () => {
       expect(response instanceof Promise).toBeTruthy()
     })
 
-    test('throws one error if receives a invalid URL', async () => {
+    it('throws one error if receives a invalid URL', async () => {
       global.fetch = jest.fn(() => new Promise((_, reject) => reject('Network response was not ok')))
       const VASTHandler = new VMAPManager()
 
@@ -27,7 +27,7 @@ describe('VMAPManager', () => {
   })
 
   describe('filterRawData method', () => {
-    test('returns one array with AdBreaks', () => {
+    it('returns one array with AdBreaks', () => {
       const VASTHandler = new VMAPManager()
 
       const response = VASTHandler.filterRawData(standardParsedVMAPMock)
@@ -38,7 +38,7 @@ describe('VMAPManager', () => {
       expect(Object.keys(response[2])).toEqual([ 'category', 'adTag', 'timeOffset' ])
     })
 
-    test('supports IAB VMAP format', () => {
+    it('supports IAB VMAP format', () => {
       const VASTHandler = new VMAPManager()
 
       const response = VASTHandler.filterRawData(standardParsedVMAPMock)
@@ -46,7 +46,7 @@ describe('VMAPManager', () => {
       expect(response[0].adTag).toHaveProperty('@templateType')
     })
 
-    test('supports Custom VMAP format', () => {
+    it('supports Custom VMAP format', () => {
       const VASTHandler = new VMAPManager()
 
       const response = VASTHandler.filterRawData(customParsedVMAPMock)
@@ -54,7 +54,7 @@ describe('VMAPManager', () => {
       expect(Array.isArray(response[0].adTag)).not.toHaveProperty('@templateType')
     })
 
-    test('returns a rejected promise for IAB VMAP format decode errors', async () => {
+    it('returns a rejected promise for IAB VMAP format decode errors', async () => {
       const VASTHandler = new VMAPManager()
       const invalidStandardVMAP = standardParsedVMAPMock
       invalidStandardVMAP['vmap:AdBreak'] = 'invalid'
@@ -62,7 +62,7 @@ describe('VMAPManager', () => {
       await expect(VASTHandler.filterRawData(invalidStandardVMAP)).rejects.toThrow('Cannot read property \'vmap:AdTagURI\' of undefined')
     })
 
-    test('returns a rejected promise for Custom VMAP format decode errors', async () => {
+    it('returns a rejected promise for Custom VMAP format decode errors', async () => {
       const VASTHandler = new VMAPManager()
 
       await expect(VASTHandler.filterRawData({ p: null, q: null })).rejects.toThrow('Cannot read property \'Ad\' of null')

--- a/src/utils/srt-to-time.test.js
+++ b/src/utils/srt-to-time.test.js
@@ -1,13 +1,13 @@
 import { hmsToMilliseconds } from './str-to-time'
 
 describe('hmsToMilliseconds', () => {
-  test('parses one duration string to milliseconds', () => {
+  it('parses one duration string to milliseconds', () => {
     const result = hmsToMilliseconds('10:34:17')
 
     expect(result).toEqual(38057000)
   })
 
-  test('returns null for non string value', () => {
+  it('returns null for non string value', () => {
     expect(hmsToMilliseconds({})).toBeNull()
   })
 })


### PR DESCRIPTION
## Summary

Depends on the inclusion of the [Feature: optimized pods](https://github.com/clappr/clappr-ima-parser/pull/3)

This PR is responsible for allowing the reading of a playlist with several advertisements coming from the same segment

## Changes

`src/parsers/vast/vast.js`: adds support to get multiple ads from the same segment

## How to test
1. Access `clappr-ima-parser` on branch(`feature/multiple-ads-ima-parser-lib`) and then run the following commands: `yarn link` and `yarn run watch`.
2. In a new terminal, you must access the `player-plugins` folder in the branch(`feature/multiple-ads-ima-parser-lib`) and then run the following commands: ﻿
  a. `yarn link "@clappr/ima-parser"`
  b. `yarn link`
  c. `yarn run watch`
3. For show `ads` you need to execute thoses especific steps first: [Show pubads during the video](https://gitlab.globoi.com/videos-5/player-plugins/-/merge_requests/167#how-to-test)
4. Open a new terminal, access `player-tvs-lite` and run: 
  a. `yarn link "@player/plugins"` ﻿
  b. `yarn start`
﻿5. On the console, trigger the event `this.player.container.trigger('ads:request:ready’)`
6. Add a debugger in the `ads_manager.js` file below line 110
7. Using a debugging proxy tool such as [Proxyman](https://proxyman.io/), intercept the responses from `https://pubads.g.doubleclick.net/gampad/ads?` and change the body of the VMAP so that it only has the items from the `PreRoll`
  a. You should ignore the first intercepted item and only change the second intercepted item with this URL.
8. When running, check when the debugger fires that `adsQueue` has the same amount of items as you configured in `PreRoll`
9. To simulate an error, you can change one of the PreRoll body items by looking for `vad_type` and changing the text to `nonlinear` and verifying that only the item with no error will be displayed.


## After this PR

- Expectation:
![ads-multiple-ima-paser](https://user-images.githubusercontent.com/96535792/171276894-19040ddd-0735-420b-8ff7-63816df506f0.png)

- Error:
![ads-multiple-error-ima-paser](https://user-images.githubusercontent.com/96535792/171276946-533df14c-dbdd-4f18-96bd-6b05ead2cf2a.png)



