### PR TITLE
Feature: Options Ajax and timeout parameter for VAST requests

### DIFF
--- a/src/ima-parser.js
+++ b/src/ima-parser.js
@@ -29,10 +29,11 @@ export default class IMAParser {
   /**
    * Get a list of ads available from the received Ad tag.
    * @param {Object} adTag  Ad tag URL to fetch VAST.
+   * @param {Object} timeout  A custom timeout for the requests.
    * @returns {Promise} Promise resolved with current available ads of the respected Ad tag.
    */
-  requestAds(adTag) {
-    return this.VASTHandler.request(adTag)
+  requestAds(adTag, timeout) {
+    return this.VASTHandler.request(adTag, timeout)
       .then(ad => ad)
       .catch(error => Promise.reject(error))
   }

--- a/src/ima-parser.js
+++ b/src/ima-parser.js
@@ -10,11 +10,11 @@ export default class IMAParser {
 
   /**
    * Get a list of AdBreaks from the received URL.
-   * @param {String} url Ad Server URL to fetch VMAP XML.
+   * @param {Object} options ajax options.
    * @returns {Promise} Promise resolved with one array of AdBreaks or one error.
    */
-  requestAdBreaks(url) {
-    return this._VMAPHandler.request(url)
+  requestAdBreaks(options) {
+    return this._VMAPHandler.request(options)
       .then(rawAdBreak => this._VMAPHandler.filterRawData(rawAdBreak))
       .then(adBreaks => {
         Log.info(this.name, 'Available adBreaks: ', adBreaks)
@@ -33,9 +33,7 @@ export default class IMAParser {
    */
   requestAds(adTag) {
     return this.VASTHandler.request(adTag)
-      .then(ad => {
-        return ad
-      })
+      .then(ad => ad)
       .catch(error => Promise.reject(error))
   }
 }

--- a/src/ima-parser.test.js
+++ b/src/ima-parser.test.js
@@ -19,7 +19,7 @@ describe('IMAParser', () => {
     it('returns a promise', () => {
       const imaParser = new IMAParser()
       jest.spyOn(imaParser._VMAPHandler, 'request').mockImplementationOnce(() => new Promise(resolve => resolve(standardParsedVMAPMock)))
-      const result = imaParser.requestAdBreaks('https://server.com/vmap')
+      const result = imaParser.requestAdBreaks({ url: 'https://server.com/vmap' })
 
       expect(result instanceof Promise).toBeTruthy()
     })
@@ -28,9 +28,9 @@ describe('IMAParser', () => {
       const imaParser = new IMAParser()
       jest.spyOn(imaParser._VMAPHandler, 'request').mockImplementationOnce(() => new Promise(resolve => resolve(standardParsedVMAPMock)))
 
-      imaParser.requestAdBreaks('https://server.com/vmap')
+      imaParser.requestAdBreaks({ url: 'https://server.com/vmap' })
         .then(result => {
-          expect(Object.keys(result[0])).toEqual([ 'category', 'adTag', 'timeOffset' ])
+          expect(Object.keys(result[0])).toEqual(['category', 'adTag', 'timeOffset'])
           done()
         })
     })
@@ -38,7 +38,7 @@ describe('IMAParser', () => {
     it('returns one error after the returned promise is rejected', done => {
       const imaParser = new IMAParser()
       jest.spyOn(imaParser._VMAPHandler, 'request').mockImplementationOnce(() => new Promise((_, reject) => reject('expected error')))
-      imaParser.requestAdBreaks('https://server.com/vmap')
+      imaParser.requestAdBreaks({ url: 'https://server.com/vmap' })
         .catch(error => {
           expect(error).toEqual('expected error')
           done()

--- a/src/parsers/vmap/vmap.js
+++ b/src/parsers/vmap/vmap.js
@@ -5,13 +5,13 @@ import xml2json from '@/converts/xml2json'
 export default class VMAPManager {
   /**
    * Request VMAP XML and parses to JSON.
-   * @param {String} URL ad server URL to request VMAP file.
+   * @param {Object} options ajax options.
    * @returns {Promise} Promise resolved with raw AdBreaks list or one error.
    */
-  request(url) {
+  request(options = {}) {
     return new Promise((resolve, reject) => {
       $.ajax({
-        url,
+        ...options,
         type: 'GET',
         dataType: 'xml',
         success: data => resolve(xml2json(data.documentElement)),
@@ -57,7 +57,7 @@ export default class VMAPManager {
         const adBreak = {
           category,
           adTag: item['vmap:AdSource']['vmap:AdTagURI'],
-          timeOffset: this.formatTimeOffset(timeOffset)
+          timeOffset: this.formatTimeOffset(timeOffset),
         }
 
         adBreaks.push(adBreak)
@@ -80,13 +80,11 @@ export default class VMAPManager {
         // Formatting all ad breaks with same structure to simplify manipulations.
         adData = Array.isArray(adData) ? adData : [adData]
 
-        const adBreak = adData.map(content => {
-          return {
-            category,
-            adTag: content.Ad,
-            timeOffset: this.formatTimeOffset(content['@timeOffset'])
-          }
-        })
+        const adBreak = adData.map(content => ({
+          category,
+          adTag: content.Ad,
+          timeOffset: this.formatTimeOffset(content['@timeOffset']),
+        }))
 
         adBreaks.push(...adBreak)
       }
@@ -103,7 +101,7 @@ export default class VMAPManager {
    * @param {Object} adBreakConfig
    * @returns {Object} adBreakConfig
    */
-   formatTimeOffset(timeOffset) {
+  formatTimeOffset(timeOffset) {
     return timeOffset ? hmsToMilliseconds(timeOffset) : null
   }
 }

--- a/src/parsers/vmap/vmap.test.js
+++ b/src/parsers/vmap/vmap.test.js
@@ -1,71 +1,67 @@
 /**
  * @jest-environment jsdom
  */
-
 import VMAPManager from './vmap'
 import { customParsedVMAPMock, standardParsedVMAPMock } from '@/mocks/valid-vmap'
 
 describe('VMAPManager', () => {
-  afterEach(() => { fetch.mockClear() })
-
   describe('request method', () => {
     it('returns a promise', () => {
-      global.fetch = jest.fn(() => new Promise(resolve => resolve({ ok: 200, text: () => {} })))
-
-      const VASTHandler = new VMAPManager()
-      const response = VASTHandler.request('https://ad-server.com/test')
+      const VMAPHandler = new VMAPManager()
+      VMAPHandler.request = jest.fn(() => new Promise(resolve => resolve({ ok: 200, text: () => {} })))
+      const response = VMAPHandler.request({ url: 'https://ad-server.com/test' })
 
       expect(response instanceof Promise).toBeTruthy()
     })
 
-    it('throws one error if receives a invalid URL', async () => {
-      global.fetch = jest.fn(() => new Promise((_, reject) => reject('Network response was not ok')))
-      const VASTHandler = new VMAPManager()
+    it('throws one error if receives a invalid URL', async() => {
+      const VMAPHandler = new VMAPManager()
+      VMAPHandler.request = jest.fn(() => new Promise((_, reject) => reject('Network response was not ok')))
 
-      await expect(VASTHandler.request('https://invali-ad-server.com/test')).rejects.toMatch('Network response was not ok')
+      await expect(VMAPHandler.request({ url: 'https://invali-ad-server.com/test', timeout: 2000 })).rejects.toMatch('Network response was not ok')
     })
   })
 
   describe('filterRawData method', () => {
     it('returns one array with AdBreaks', () => {
-      const VASTHandler = new VMAPManager()
+      const VMAPHandler = new VMAPManager()
 
-      const response = VASTHandler.filterRawData(standardParsedVMAPMock)
+      const response = VMAPHandler.filterRawData(standardParsedVMAPMock)
 
       expect(response.length).toEqual(3)
-      expect(Object.keys(response[0])).toEqual([ 'category', 'adTag', 'timeOffset' ])
-      expect(Object.keys(response[1])).toEqual([ 'category', 'adTag', 'timeOffset' ])
-      expect(Object.keys(response[2])).toEqual([ 'category', 'adTag', 'timeOffset' ])
+      expect(Object.keys(response[0])).toEqual(['category', 'adTag', 'timeOffset'])
+      expect(Object.keys(response[1])).toEqual(['category', 'adTag', 'timeOffset'])
+      expect(Object.keys(response[2])).toEqual(['category', 'adTag', 'timeOffset'])
     })
 
     it('supports IAB VMAP format', () => {
-      const VASTHandler = new VMAPManager()
+      const VMAPHandler = new VMAPManager()
 
-      const response = VASTHandler.filterRawData(standardParsedVMAPMock)
+      const response = VMAPHandler.filterRawData(standardParsedVMAPMock)
 
       expect(response[0].adTag).toHaveProperty('@templateType')
     })
 
     it('supports Custom VMAP format', () => {
-      const VASTHandler = new VMAPManager()
+      const VMAPHandler = new VMAPManager()
 
-      const response = VASTHandler.filterRawData(customParsedVMAPMock)
+      const response = VMAPHandler.filterRawData(customParsedVMAPMock)
 
       expect(Array.isArray(response[0].adTag)).not.toHaveProperty('@templateType')
     })
 
-    it('returns a rejected promise for IAB VMAP format decode errors', async () => {
-      const VASTHandler = new VMAPManager()
+    it('returns a rejected promise for IAB VMAP format decode errors', async() => {
+      const VMAPHandler = new VMAPManager()
       const invalidStandardVMAP = standardParsedVMAPMock
       invalidStandardVMAP['vmap:AdBreak'] = 'invalid'
 
-      await expect(VASTHandler.filterRawData(invalidStandardVMAP)).rejects.toThrow('Cannot read property \'vmap:AdTagURI\' of undefined')
+      await expect(VMAPHandler.filterRawData(invalidStandardVMAP)).rejects.toThrow('Cannot read property \'vmap:AdTagURI\' of undefined')
     })
 
-    it('returns a rejected promise for Custom VMAP format decode errors', async () => {
-      const VASTHandler = new VMAPManager()
+    it('returns a rejected promise for Custom VMAP format decode errors', async() => {
+      const VMAPHandler = new VMAPManager()
 
-      await expect(VASTHandler.filterRawData({ p: null, q: null })).rejects.toThrow('Cannot read property \'Ad\' of null')
+      await expect(VMAPHandler.filterRawData({ p: null, q: null })).rejects.toThrow('Cannot read property \'Ad\' of null')
     })
   })
 })


### PR DESCRIPTION
## Summary
This PR aims to add support for ajax options parameters and timeout parameter for VAST requests.

## Changes
`src/ima-parser.js`: add options parameter for VMAP request and add timeout parameter for VAST request;
`src/ima-parser.test.js`: fix unit tests;
`src/parsers/vmap/vmap.js`: receives options parameter and uses it in ajax;
`src/parsers/vmap/vmap.test.js`: fix unit tests;
`src/parsers/vast/vast.js`: receives timeout parameter.