### PR TITLE
VMAP - Add treatment for empty VMAP playlist

### DIFF
--- a/src/parsers/vmap/vmap.js
+++ b/src/parsers/vmap/vmap.js
@@ -26,6 +26,7 @@ export default class VMAPManager {
    * @returns {Array} All AdBreaks instances created or one error.
    */
   filterRawData(rawData) {
+    if (!rawData) return []
     return rawData['@version'] && rawData['vmap:AdBreak']
       ? this._filterStandardRawData(rawData)
       : this._filterCustomRawData(rawData)

--- a/src/parsers/vmap/vmap.test.js
+++ b/src/parsers/vmap/vmap.test.js
@@ -54,14 +54,16 @@ describe('VMAPManager', () => {
       const VMAPHandler = new VMAPManager()
       const invalidStandardVMAP = standardParsedVMAPMock
       invalidStandardVMAP['vmap:AdBreak'] = 'invalid'
+      const expectedErrorMessage = 'Cannot read properties of undefined (reading \'vmap:AdTagURI\')'
 
-      await expect(VMAPHandler.filterRawData(invalidStandardVMAP)).rejects.toThrow('Cannot read property \'vmap:AdTagURI\' of undefined')
+      await expect(VMAPHandler.filterRawData(invalidStandardVMAP)).rejects.toThrow(expectedErrorMessage)
     })
 
     it('returns a rejected promise for Custom VMAP format decode errors', async() => {
       const VMAPHandler = new VMAPManager()
+      const expectedErrorMessage = 'Cannot read properties of null (reading \'Ad\')'
 
-      await expect(VMAPHandler.filterRawData({ p: null, q: null })).rejects.toThrow('Cannot read property \'Ad\' of null')
+      await expect(VMAPHandler.filterRawData({ p: null, q: null })).rejects.toThrow(expectedErrorMessage)
     })
   })
 })

--- a/src/parsers/vmap/vmap.test.js
+++ b/src/parsers/vmap/vmap.test.js
@@ -23,6 +23,14 @@ describe('VMAPManager', () => {
   })
 
   describe('filterRawData method', () => {
+    it('returns empty array for empty VMAP playlist', () => {
+      const VMAPHandler = new VMAPManager()
+
+      const response = VMAPHandler.filterRawData(null)
+
+      expect(response.length).toEqual(0)
+    })
+
     it('returns one array with AdBreaks', () => {
       const VMAPHandler = new VMAPManager()
 


### PR DESCRIPTION
Currently, there is no treatment for an empty VMAP response:
```
<Playlist/>
```
The `filterRawData` generates an error:
```
Cannot read properties of null (reading '@version')
```

Now, when the `rawData` is `null`, an empty array is returned.

