### PR TITLE
Prevent exception on empty VMAP response

### DIFF
--- a/src/parsers/vmap/vmap.js
+++ b/src/parsers/vmap/vmap.js
@@ -64,7 +64,7 @@ export default class VMAPManager {
         adBreaks.push(adBreak)
       })
     } catch (error) {
-      Log.error(this.name, 'Build AdBreak process fail', error)
+      Log.error('VMAP', 'Build AdBreak process fail', error)
       return Promise.reject(error)
     }
 
@@ -90,7 +90,7 @@ export default class VMAPManager {
         adBreaks.push(...adBreak)
       }
     } catch (error) {
-      Log.error(this.name, 'Build AdBreak process fail', error)
+      Log.error('VMAP', 'Build AdBreak process fail', error)
       return Promise.reject(error)
     }
 

--- a/src/parsers/vmap/vmap.js
+++ b/src/parsers/vmap/vmap.js
@@ -14,6 +14,7 @@ export default class VMAPManager {
     return new Promise((resolve, reject) => {
       urlHandler.get(url, { timeout }, (error, xml) => {
         if (error) return reject(error)
+        if (!xml) return reject({ message: 'Invalid empty response' })
         resolve(xml2json(xml))
       })
     })


### PR DESCRIPTION
This MR updates the VMAP response handler to check if the `xml` returned by the request is empty. 
The response should not be parsed and an error is returned in this case.

Besides that, some logs were updated updating undefined data.